### PR TITLE
Removed print-statements from sharpness computation

### DIFF
--- a/mosqito/functions/sharpness/sharpness_aures.py
+++ b/mosqito/functions/sharpness/sharpness_aures.py
@@ -40,7 +40,6 @@ def comp_sharpness_aures(N, N_specific, is_stationary):
             gA = np.zeros((z.size))
             gA = 0.078 * (np.exp(0.171 * z) / z) * (N / np.log(N * 0.05 + 1))
             S = 0.11 * sum(N_specific * gA * z * 0.1) / N
-            print("Aures sharpness:", "%.2f" % S, "acum")
     else:
         S = np.zeros((N.size))
         gA = np.zeros((z.size, N.size))

--- a/mosqito/functions/sharpness/sharpness_bismarck.py
+++ b/mosqito/functions/sharpness/sharpness_bismarck.py
@@ -43,7 +43,6 @@ def comp_sharpness_bismarck(N, N_specific, is_stationary):
             S = 0
         else:
             S = 0.11 * sum(N_specific * gB * z * 0.1) / N
-            print("Bismarck sharpness:", "%.2f" % S, "acum")
     else:
         S = np.zeros((N.size))
         for t in range(N.size):

--- a/mosqito/functions/sharpness/sharpness_din.py
+++ b/mosqito/functions/sharpness/sharpness_din.py
@@ -43,7 +43,6 @@ def comp_sharpness_din(N, N_specific, is_stationary):
             S = 0
         else:
             S = 0.11 * sum(N_specific * gDIN * z * 0.1) / N
-            print("DIN sharpness:", "%.2f" % S, "acum")
     else:
         S = np.zeros((N.size))
         for t in range(N.size):

--- a/mosqito/functions/sharpness/sharpness_fastl.py
+++ b/mosqito/functions/sharpness/sharpness_fastl.py
@@ -146,7 +146,6 @@ def comp_sharpness_fastl(N, N_specific, is_stationary):
             S = 0
         else:
             S = 0.11 * sum(N_specific * gZF * z * 0.1) / N
-            print("Fastl sharpness:", "%.2f" % S, "acum")
     else:
         S = np.zeros((N.size))
         for t in range(N.size):


### PR DESCRIPTION
When applying the sharpness computation functions the standard output is cluttered with output. I use Mosqito from within another application and these functions writing to the terminal seems very strange and un-neccesary.