### PR TITLE
Check if Zwicker method can be applied and raise ValueError if it can't

### DIFF
--- a/mosqito/functions/loudness_zwicker/loudness_zwicker_shared.py
+++ b/mosqito/functions/loudness_zwicker/loudness_zwicker_shared.py
@@ -34,6 +34,15 @@ def calc_main_loudness(spec_third, field_type):
     nm :  numpy.ndarray
         Core loudness
     """
+    # Ref. ISO 532-1:2017 paragraph A.3
+    # The table A.3 giving the weights of the 1/3 band levels for
+    # center freq. below 300 Hz is only specified for levels up to 120 dB
+    # If one of the first 11 bands (from 25 to 250 Hz) exceed 120 dB the
+    # Zwicker method cannot be applied.
+    if np.max(spec_third[0:11]) > 120.0:
+        raise ValueError("1/3 octave band value exceed 120 dB, for which " +
+                         "the Zwicker method is no longer valid.")
+
     #
     # Date tables definition (variable names and description according to
     # Zwicker:1991)


### PR DESCRIPTION
Ref. ISO 532-1:2017 paragraph A.3

The table A.3 giving the weights of the 1/3 band levels for
center freq. below 300 Hz is only specified for levels up to 120 dB
If one of the first 11 bands (from 25 to 250 Hz) exceed 120 dB the
Zwicker method cannot be applied.

The following small Python program demonstrate the problem:
```from mosqito.functions.loudness_zwicker.sone_to_phon import sone_to_phon
from mosqito.functions.loudness_zwicker.comp_loudness import \
    comp_loudness_from_3spec
import numpy as np

spec_third = np.array([
    -60.,
    72.81982796,
    75.02877195,
    76.77521407,
    75.74044304,
    76.28867638,
    81.1369093,
    78.10383462,
    77.11103446,
    88.17833045,
    122.08840462,  # <- Problem with this band (250 Hz)
    120.56022017,
    82.57685237,
    81.70341169,
    73.70823606,
    75.76547571,
    76.15397857,
    71.07174789,
    74.87522753,
    67.70714846,
    67.65688453,
    62.96996558,
    62.53792231,
    58.02535465,
    58.01203941,
    54.55116421,
    52.31250338,
    51.15658175])

loudness = comp_loudness_from_3spec(True, spec_third)
Ln = sone_to_phon(loudness["values"])

print(f"Loudness: {Ln}")
```
Giving the following error:
```Traceback (most recent call last):
  File "loudness_error.py", line 36, in <module>
    loudness = comp_loudness_from_3spec(True, spec_third)
  File "/home/hakostra/.local/lib/python3.8/site-packages/mosqito/functions/loudness_zwicker/comp_loudness.py", line 96, in comp_loudness_from_3spec
    N, N_specific = loudness_zwicker_stationary(third_spec, third_axis, field_type)
  File "/home/hakostra/.local/lib/python3.8/site-packages/mosqito/functions/loudness_zwicker/loudness_zwicker_stationary.py", line 106, in loudness_zwicker_stationary
    Nm = calc_main_loudness(spec_third, field_type)
  File "/home/hakostra/.local/lib/python3.8/site-packages/mosqito/functions/loudness_zwicker/loudness_zwicker_shared.py", line 123, in calc_main_loudness
    while spec_third[i] > rap[j] - dll[j, i] and j < dll.shape[0]:
IndexError: index 8 is out of bounds for axis 0 with size 8
```
The spectrum is actually from a very loud but real data source. I do of course acknowledge that the loudness can't be computed for this data, but instead of throwing a random out-of-bounds error (indicating a programming error) it should give a ValueError that can be understood and handled by the user.

I was in doubt as of where the check should be performed, but since the `calc_main_loudness` is the first common routine for both stationary and non-stationary signals I thought that was the best place.