### PR TITLE
Frequency domain corrections for nth octave spectrum and screening for tones functions

### DIFF
--- a/mosqito/sound_level_meter/__init__.py
+++ b/mosqito/sound_level_meter/__init__.py
@@ -1,3 +1,3 @@
-from mosqito.sound_level_meter.noct_spectrum.noct_spectrum import (
-    noct_spectrum, noct_synthesis
-)
+from mosqito.sound_level_meter.noct_spectrum.noct_spectrum import noct_spectrum
+from mosqito.sound_level_meter.noct_spectrum.noct_synthesis import noct_synthesis
+

--- a/mosqito/sound_level_meter/__init__.py
+++ b/mosqito/sound_level_meter/__init__.py
@@ -1,3 +1,3 @@
 from mosqito.sound_level_meter.noct_spectrum.noct_spectrum import (
-    noct_spectrum,
+    noct_spectrum, noct_synthesis
 )

--- a/mosqito/sound_level_meter/noct_spectrum/_filter_bandwidth.py
+++ b/mosqito/sound_level_meter/noct_spectrum/_filter_bandwidth.py
@@ -54,7 +54,7 @@ def _filter_bandwidth(fc, n=3, N=3):
     # Ratio of the upper and lower band-edge frequencies to the mid-band frequency
     alpha = (1 + np.sqrt(1 + 4 * qd ** 2)) / 2 / qd
 
-    return alpha
+    return alpha, f1, f2
 
 
 if __name__ == "__main__":

--- a/mosqito/sound_level_meter/noct_spectrum/_n_oct_freq_filter.py
+++ b/mosqito/sound_level_meter/noct_spectrum/_n_oct_freq_filter.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
-"""
-Created on Thu Mar 10 10:00:03 2022
 
-@author: wantysal
-"""
+
 # Standard library imports
 import numpy as np
-from scipy.signal import butter, freqz
+from scipy.signal import butter, sosfreqz
 
-
-def _n_oct_freq_filter(spectrum, fs, fc, alpha, n=3):
+def _n_oct_freq_filter(spectrum, fs, factor, fc, alpha, n=3):  
     """ n-th octave filtering in frequency domain
 
     Designs a digital 1/3-octave filter with center frequency fc for
@@ -21,12 +17,14 @@ def _n_oct_freq_filter(spectrum, fs, fc, alpha, n=3):
         Frequency spectrum [complex]
     fs : float
         Sampling frequency [Hz]
+    factor : integer
+        Downsampling factor
     fc : float
         Filter exact center frequency [Hz]
     alpha : float
         Ratio of the upper and lower band-edge frequencies to the mid-band
         frequency
-    N : int, optional
+    n : int, optional
         Filter order. Default to 3
 
     Outputs
@@ -35,40 +33,36 @@ def _n_oct_freq_filter(spectrum, fs, fc, alpha, n=3):
         Rms level of sig in the third octave band centered on fc
     """
 
-    # Check for Nyquist-Shannon criteria
-    if fc > 0.88 * (fs / 2):
-        raise ValueError(
-            """ERROR: Design not possible. Filter center frequency shall
-            verify: fc <= 0.88 * (fs / 2)"""
-        )
-
     # Normalized cutoff frequencies
-    w1 = fc / (fs / 2) / alpha
-    w2 = fc / (fs / 2) * alpha
+    w1 = fc / (fs  / 2) / alpha
+    w2 = fc / (fs  / 2) * alpha
 
-    # define filter coefficient
-    b, a = butter(n, [w1, w2], "bandpass", analog=False)
+    # Define filter coefficient
+    sos = butter(n, [w1, w2], "bandpass", analog=False, output ='sos')
+    
+    # # filter signal
+    # if len(spectrum.shape)>1:
+    #     level = []
+    #     # go into frequency domain
+    #     w, h = freqz(b, a, worN=spectrum.shape[1])
+    #     for i in range(spectrum.shape[0]):
+    #         spec_filt = spectrum[i,:] * h
+    #         # Compute overall rms level
+    #         level.append(np.sqrt(np.sum(np.abs(spec_filt) ** 2)))
+    #     level = np.array(level)
+    # else:
+    #     # go into frequency domain
+    #     w, h = freqz(b, a, worN=len(spectrum))
+    #     spec_filt = spectrum * h
+    #     # Compute overall rms level
+    #     level = np.sqrt(np.sum(np.abs(spec_filt) ** 2)) 
     
     
-    # filter signal
-    if len(spectrum.shape)>1:
-        level = []
-        # go into frequency domain
-        w, h = freqz(b, a, worN=spectrum.shape[1])
-        for i in range(spectrum.shape[0]):
-            spec_filt = spectrum[i,:] * h
-            # Compute overall rms level
-            level.append(np.sqrt(np.sum(np.abs(spec_filt) ** 2)))
-        level = np.array(level)
-    else:
-        # go into frequency domain
-        w, h = freqz(b, a, worN=len(spectrum))
-        spec_filt = spectrum * h
-        # Compute overall rms level
-        level = np.sqrt(np.sum(np.abs(spec_filt) ** 2)) 
+    # Get FRF and apply it
+    w, h = sosfreqz(sos, worN=len(spectrum))
+    spec_filt = np.multiply(h, spectrum.T).T
+    
+    # Compute overall rms level
+    level = np.sqrt(np.sum(np.abs(spec_filt) ** 2, axis=0)) 
         
     return level
-
-
-
-

--- a/mosqito/sound_level_meter/noct_spectrum/_n_oct_time_filter.py
+++ b/mosqito/sound_level_meter/noct_spectrum/_n_oct_time_filter.py
@@ -2,7 +2,7 @@
 
 # Standard library imports
 import numpy as np
-from scipy.signal import decimate, butter, lfilter
+from scipy.signal import decimate, butter, sosfilt
 
 
 def _n_oct_time_filter(sig, fs, fc, alpha, N=3):
@@ -29,7 +29,7 @@ def _n_oct_time_filter(sig, fs, fc, alpha, N=3):
     alpha : float
         Ratio of the upper and lower band-edge frequencies to the mid-band
         frequency
-    N : int, optional
+    n : int, optional
         Filter order. Default to 3
 
     Outputs
@@ -59,10 +59,10 @@ def _n_oct_time_filter(sig, fs, fc, alpha, N=3):
     w2 = fc / (fs / 2) * alpha
 
     # define filter coefficient
-    b, a = butter(N, [w1, w2], "bandpass", analog=False)
+    sos = butter(int(N), (w1, w2), "bandpass", analog=False, output='sos')
 
     # filter signal
-    sig_filt = lfilter(b, a, sig, axis=0)
+    sig_filt = sosfilt(sos, sig, axis=0)
 
     # Compute overall rms level
     level = np.sqrt(np.mean(sig_filt ** 2, axis=0))

--- a/mosqito/sound_level_meter/noct_spectrum/noct_spectrum.py
+++ b/mosqito/sound_level_meter/noct_spectrum/noct_spectrum.py
@@ -53,11 +53,12 @@ def noct_spectrum(sig, fs, fmin, fmax, n=3, G=10, fr=1000):
     fc_vec, fpref = _center_freq(fmin=fmin, fmax=fmax, n=n, G=G, fr=fr)
 
     # Compute the filters bandwidth
-    alpha_vec = _filter_bandwidth(fc_vec, n=n)
+    alpha_vec, _, _ = _filter_bandwidth(fc_vec, n=n)
 
     # Calculation of the rms level of the signal in each band
     spec = []
     for fc, alpha in zip(fc_vec, alpha_vec):
+        print(fc, alpha)
         spec.append(_n_oct_time_filter(sig, fs, fc, alpha))
 
     return np.array(spec), fpref

--- a/mosqito/sound_level_meter/noct_spectrum/noct_synthesis.py
+++ b/mosqito/sound_level_meter/noct_spectrum/noct_synthesis.py
@@ -71,4 +71,4 @@ def noct_synthesis(spectrum, freqs, fmin, fmax, n=3, G=10, fr=1000):
     for fc, alpha in zip(fc_vec, alpha_vec):
         spec.append(_n_oct_freq_filter(spectrum, fs, fc, alpha))
 
-    return spec, fpref
+    return np.array(spec), fpref

--- a/mosqito/sq_metrics/tonality/prominence_ratio_ecma/_pr_main_calc.py
+++ b/mosqito/sq_metrics/tonality/prominence_ratio_ecma/_pr_main_calc.py
@@ -205,9 +205,7 @@ def _pr_main_calc(spectrum_db, freq_axis):
 
             # suppression from the list of tones of all the candidates belonging to the
             # same critical band
-            sup = np.where((peaks >= low_limit_idx) & (peaks <= high_limit_idx))[
-                0
-            ]
+            sup = np.where((peaks >= low_limit_idx) & (peaks <= high_limit_idx))[0]
             peaks = np.delete(peaks, sup)
             nb_tones -= len(sup)
 

--- a/mosqito/sq_metrics/tonality/tone_to_noise_ecma/_screening_for_tones.py
+++ b/mosqito/sq_metrics/tonality/tone_to_noise_ecma/_screening_for_tones.py
@@ -8,9 +8,7 @@ Created on Wed Dec 16 20:23:01 2020
 import numpy as np
 
 # Mosqito functions import
-from mosqito.sq_metrics.tonality.tone_to_noise_ecma._spectrum_smoothing import (
-    _spectrum_smoothing,
-)
+from mosqito.sq_metrics.tonality.tone_to_noise_ecma._spectrum_smoothing import _spectrum_smoothing
 from mosqito.sq_metrics.tonality.tone_to_noise_ecma._LTH import _LTH
 from mosqito.sq_metrics.tonality.tone_to_noise_ecma._critical_band import _critical_band
 
@@ -54,7 +52,7 @@ def _screening_for_tones(freqs, spec_db, method, low_freq, high_freq):
     # Detection of the tonal candidates according to their level
 
     # Creation of the smoothed spectrum
-    smooth_spec = _spectrum_smoothing(freqs, spec_db, 24, low_freq, high_freq, freqs)
+    smooth_spec = _spectrum_smoothing(freqs, spec_db.T, 24, low_freq, high_freq, freqs).T
     
     
     n = spec_db.shape[0]
@@ -149,7 +147,7 @@ def _screening_for_tones(freqs, spec_db, method, low_freq, high_freq):
         # Screen the left points of the peak
         temp = peak_index - 1
         # As long as the level decreases,
-        while (spec_db[temp] > smooth_spec[temp] + 6) and (temp + 1 < (block+1)*m):
+        while (spec_db[temp] > smooth_spec[temp] + 6) and (temp +1 > (block)*m):
             # if a highest spectral line is found, it becomes the candidate
             if spec_db[temp] > spec_db[peak_index]:
                 peak_index = temp

--- a/mosqito/sq_metrics/tonality/tone_to_noise_ecma/_spectrum_smoothing.py
+++ b/mosqito/sq_metrics/tonality/tone_to_noise_ecma/_spectrum_smoothing.py
@@ -18,9 +18,9 @@ def _spectrum_smoothing(freqs_in, spec, noct, low_freq, high_freq, freqs_out):
     Parameters
     ----------
     freqs : numpy.array
-        frequency axis (frequency axis)
+        frequency axis dim (nperseg)
     spec : numpy.array
-        spectrum in dB (n block x spectrum)
+        spectrum in dB (nperseg, nseg)
     noct : integer
         n-th octave-band according to which smooth the spectrum
     low_freq : float
@@ -36,14 +36,13 @@ def _spectrum_smoothing(freqs_in, spec, noct, low_freq, high_freq, freqs_out):
         smoothed spectrum along the given frequency axis
 
     """
-    n = spec.shape[0]
+    nperseg = spec.shape[0]
     if len(spec.shape) > 1:
-        m = spec.shape[1]
+        nseg = spec.shape[1]
     else:
-        m = spec.shape[0]
-        n = 1
+        nseg = 1
     spec = spec.ravel()
-    stop = np.arange(1, n + 1) * m
+    stop = np.arange(1, nseg + 1) * nperseg
     freqs_in = freqs_in.ravel()
 
     # n-th octave bands filter
@@ -53,14 +52,12 @@ def _spectrum_smoothing(freqs_in, spec, noct, low_freq, high_freq, freqs_out):
 
     # Smoothed spectrum creation
     nb_bands = filter_freqs.shape[0]
-    smoothed_spectrum = np.zeros((n, nb_bands))
+    smoothed_spectrum = np.zeros((nb_bands, nseg))
     i = 0
     # Each band is considered individually until all of them have been treated
     while nb_bands > 0:
         # Find the index of the spectral components within the frequency bin
-        bin_index = np.where(
-            (freqs_in >= filter_freqs[i, 0]) & (freqs_in <= filter_freqs[i, 2])
-        )[0]
+        bin_index = np.where((freqs_in >= filter_freqs[i, 0]) & (freqs_in <= filter_freqs[i, 2]))[0]
 
         # If the frequency bin is empty, it is deleted from the list
         if len(bin_index) == 0:
@@ -70,45 +67,32 @@ def _spectrum_smoothing(freqs_in, spec, noct, low_freq, high_freq, freqs_out):
 
         else:
             # The spectral components within the frequency bin are averaged on an energy basis
-            spec_sum = np.zeros((n))
-            for j in range(n):
-                if (
-                    len(bin_index[(bin_index < stop[j]) & (bin_index > (stop[j] - m))])
-                    != 0
-                ):
-                    spec_sum[j] = np.mean(
-                        10
-                        ** (
-                            spec[
-                                bin_index[
-                                    (bin_index < stop[j]) & (bin_index > (stop[j] - m))
-                                ]
-                            ]
-                            / 10
-                        )
-                    )
+            spec_sum = np.zeros((nseg))
+            for j in range(nseg):
+                if len(bin_index[(bin_index < stop[j]) & (bin_index > (stop[j] - nperseg))])!= 0:
+                    spec_sum[j] = np.mean(10** (spec[bin_index[(bin_index < stop[j]) & (bin_index > (stop[j] - nperseg))]]/ 10))
                 else:
                     spec_sum[j] = 1e-12
-            smoothed_spectrum[:, i] = 10 * np.log10(
-                spec_sum
-                # / len(bin_index[(bin_index < stop[j]) & (bin_index > (stop[j] - m))])
-            )
+            smoothed_spectrum[i, :] = 10 * np.log10(spec_sum)# / len(bin_index[(bin_index < stop[j]) & (bin_index > (stop[j] - m))]))
         nb_bands -= 1
         i += 1
     # Pose of the smoothed spectrum on the frequency-axis
-    low = np.zeros((n, filter_freqs.shape[0]))
-    high = np.zeros((n, filter_freqs.shape[0]))
+    low = np.zeros((filter_freqs.shape[0], nseg))
+    high = np.zeros((filter_freqs.shape[0], nseg))
 
     # Index of the lower and higher limit of each frequency bin into the original spectrum
     for i in range(len(filter_freqs)):
-        low[:, i] = np.argmin(np.abs(freqs_out - filter_freqs[i, 0]))
-        high[:, i] = np.argmin(np.abs(freqs_out - filter_freqs[i, 2]))
+        low[i,:] = np.argmin(np.abs(freqs_out - filter_freqs[i, 0]))
+        high[i,:] = np.argmin(np.abs(freqs_out - filter_freqs[i, 2]))
     low = low.astype(int)
     high = high.astype(int)
 
-    smooth_spec = np.zeros((n, m))
-    for i in range(n):
+    smooth_spec = np.zeros((nperseg, nseg))
+    for i in range(nseg):
         for j in range(filter_freqs.shape[0]):
-            smooth_spec[i, low[i, j] : high[i, j]] = smoothed_spectrum[i, j]
+            smooth_spec[low[j,i] : high[j,i], i] = smoothed_spectrum[j,i]
+    
+    if smooth_spec.shape[1] == 1:
+        smooth_spec = np.squeeze(smooth_spec)
 
     return smooth_spec

--- a/tests/sound_level_meter/noct_spectrum/test_noct_synthesis.py
+++ b/tests/sound_level_meter/noct_spectrum/test_noct_synthesis.py
@@ -7,7 +7,7 @@ except ImportError:
     raise RuntimeError(
         "In order to perform the tests you need the 'pytest' package."
     )
-# import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt
 
 # External library imports
 import numpy as np
@@ -24,9 +24,10 @@ def _dB(amp):
 
 
 @pytest.mark.noct_synthesis  # to skip or run only loudness noct_synthesis tests
-def test_noct_synthesis():
-    sig, fs = load(
-        "tests/input/Test signal 5 (pinknoise 60 dB).wav", wav_calib=2*2**0.5)
+def test_noct_synthesis_technical():
+    
+    ############################## TECHNICAL SIGNAL ##########################
+    sig, fs = load("tests\input\Test signal 5 (pinknoise 60 dB).wav", wav_calib=2*2**0.5)
 
     spec_3t, freq_3t = noct_spectrum(sig, fs, fmin=24, fmax=12600, n=3)
     spec_1t, freq_1t = noct_spectrum(sig, fs, fmin=24, fmax=12600, n=1)
@@ -41,10 +42,8 @@ def test_noct_synthesis():
     # Frequency axis
     freqs = fftfreq(n, 1/fs)[0:n//2]
 
-    spec_3f, freq_3f = noct_synthesis(
-        np.abs(spectrum), freqs, fmin=24, fmax=12600, n=3)
-    spec_1f, freq_1f = noct_synthesis(
-        np.abs(spectrum), freqs, fmin=24, fmax=12600, n=1)
+    spec_3f, freq_3f = noct_synthesis(np.abs(spectrum), freqs, fmin=24, fmax=12600, n=3)
+    spec_1f, freq_1f = noct_synthesis(np.abs(spectrum), freqs, fmin=24, fmax=12600, n=1)
 
     # plt.figure()
     # plt.semilogx(freq_3t, _dB(spec_3t), label='noct spectrum')
@@ -60,8 +59,48 @@ def test_noct_synthesis():
 
     np.testing.assert_allclose(_dB(spec_3t[:, 0]), _dB(spec_3f), atol=0.3)
     np.testing.assert_allclose(_dB(spec_1t[:, 0]), _dB(spec_1f), atol=0.3)
+    
+    
+# @pytest.mark.noct_synthesis  # to skip or run only loudness noct_synthesis tests
+# def test_noct_synthesis_synthetic():
+
+#     ########################## SYNTHETIC SIGNAL###############################
+#     sig, fs = load("tests\input\white_noise_200_2000_Hz_stationary.wav", wav_calib=2*2**0.5)
+
+#     spec_3t, freq_3t = noct_spectrum(sig, fs, fmin=24, fmax=12600, n=3)
+#     spec_1t, freq_1t = noct_spectrum(sig, fs, fmin=24, fmax=12600, n=1)
+
+#     # Creation of the spectrum by FFT
+#     # 2* because we consider a one-sided spectrum
+#     # /np.sqrt(2) to go from amplitude peak to amplitude RMS
+#     # /n normalization for the numpy fft function
+#     n = len(sig)
+#     spectrum = 2 / np.sqrt(2) / n * fft(sig)[0:n//2]
+
+#     # Frequency axis
+#     freqs = fftfreq(n, 1/fs)[0:n//2]
+
+#     spec_3f, freq_3f = noct_synthesis(np.abs(spectrum), freqs, fmin=24, fmax=12600, n=3)
+#     spec_1f, freq_1f = noct_synthesis(np.abs(spectrum), freqs, fmin=24, fmax=12600, n=1)
+
+#     plt.figure()
+#     plt.semilogx(freq_3t, _dB(spec_3t), label='noct spectrum')
+#     plt.semilogx(freq_3f, _dB(spec_3f), label='noct synth')
+#     plt.legend()
+
+#     plt.figure()
+#     plt.semilogx(freq_1t, _dB(spec_1t), label='noct spectrum')
+#     plt.semilogx(freq_1f, _dB(spec_1f), label='noct synth')
+#     plt.legend()
+
+#     plt.show()
+
+#     np.testing.assert_allclose(_dB(spec_3t[:, 0]), _dB(spec_3f), atol=0.3)
+#     np.testing.assert_allclose(_dB(spec_1t[:, 0]), _dB(spec_1f), atol=0.3)
+
 
 
 # test de la fonction
 if __name__ == "__main__":
-    test_noct_synthesis()
+    test_noct_synthesis_technical()
+    # test_noct_synthesis_synthetic()

--- a/tests/sound_level_meter/noct_spectrum/test_noct_synthesis.py
+++ b/tests/sound_level_meter/noct_spectrum/test_noct_synthesis.py
@@ -27,7 +27,7 @@ def _dB(amp):
 def test_noct_synthesis_technical():
     
     ############################## TECHNICAL SIGNAL ##########################
-    sig, fs = load("tests\input\Test signal 5 (pinknoise 60 dB).wav", wav_calib=2*2**0.5)
+    sig, fs = load("tests/input/Test signal 5 (pinknoise 60 dB).wav", wav_calib=2*2**0.5)
 
     spec_3t, freq_3t = noct_spectrum(sig, fs, fmin=24, fmax=12600, n=3)
     spec_1t, freq_1t = noct_spectrum(sig, fs, fmin=24, fmax=12600, n=1)

--- a/tests/sq_metrics/tonality/test_pr_ecma_st.py
+++ b/tests/sq_metrics/tonality/test_pr_ecma_st.py
@@ -8,7 +8,7 @@ except ImportError:
         "In order to perform the tests you need the 'pytest' package."
     )
 
-
+import numpy as np
 # Local application imports
 from mosqito.utils import load
 from mosqito.sq_metrics import pr_ecma_st
@@ -30,17 +30,20 @@ def test_pr_ecma_st():
     None
     """
     # Test signal as input for prominence ratio calculation
-    # signals generated using audacity : white noise + tones at 200 and 2000 Hz
+    # signals generated using audacity : white noise + tones at 442 and 1768 Hz
 
     signal = {
             "data_file": "tests/input/white_noise_442_1768_Hz_stationary.wav"
         }
 
     # Load signal
-    audio, fs = load(signal["data_file"])
+    audio, fs = load(signal["data_file"], wav_calib=0.01)
 
     # Compute tone-to-noise ratio
-    t_pr, pr, prom, tones_freqs = pr_ecma_st(audio, fs, prominence=True)
+    t_pr, pr, prom, freq = pr_ecma_st(audio, fs, prominence=True)
+    np.testing.assert_almost_equal(t_pr, 32.20980078537321)
+    np.testing.assert_almost_equal(freq.astype(np.int32), [442, 1768])
+    assert np.count_nonzero(prom == True) == 2
 
 
 if __name__ == "__main__":

--- a/tests/sq_metrics/tonality/test_pr_ecma_st.py
+++ b/tests/sq_metrics/tonality/test_pr_ecma_st.py
@@ -40,9 +40,7 @@ def test_pr_ecma_st():
     audio, fs = load(signal["data_file"])
 
     # Compute tone-to-noise ratio
-    pr = pr_ecma_st( audio, fs, prominence=True)
-
-
+    t_pr, pr, prom, tones_freqs = pr_ecma_st(audio, fs, prominence=True)
 
 
 if __name__ == "__main__":

--- a/tests/sq_metrics/tonality/test_pr_ecma_tv.py
+++ b/tests/sq_metrics/tonality/test_pr_ecma_tv.py
@@ -8,7 +8,7 @@ except ImportError:
         "In order to perform the tests you need the 'pytest' package."
     )
 
-
+import numpy as np
 # Local application imports
 from mosqito.utils import load
 from mosqito.sq_metrics import pr_ecma_tv
@@ -30,18 +30,21 @@ def test_pr_ecma_tv():
     None
     """
     # Test signal as input for prominence ratio calculation
-    # signals generated using audacity : white noise + tones at 200 and 2000 Hz
+    # signals generated using audacity : white noise + tones at 442 and 1768 Hz
 
     signal = {
             "data_file": "tests/input/white_noise_442_1768_Hz_varying.wav"
         }
 
     # Load signal
-    audio, fs = load(signal["data_file"])
+    audio, fs = load(signal["data_file"], wav_calib=0.01)
 
     # Compute tone-to-noise ratio
-    t_pr, pr, prom, freq, time = pr_ecma_tv( audio, fs, prominence=True)
-
+    t_pr, pr, prom, freq, time = pr_ecma_tv(audio, fs, prominence=True)
+    np.testing.assert_almost_equal(max(t_pr), 34.02082433185258)
+    assert pr[np.argmin(np.abs(freq-442)),:].all() != np.nan
+    assert pr[np.argmin(np.abs(freq-1768)),2:3].all() != np.nan
+    assert np.count_nonzero(prom == True) == 8
 
 
 

--- a/tests/sq_metrics/tonality/test_tnr_ecma_st.py
+++ b/tests/sq_metrics/tonality/test_tnr_ecma_st.py
@@ -41,7 +41,7 @@ def test_tnr_ecma_st():
     # Load signal
     audio, fs = load(signal["data_file"])
     # Compute tone-to-noise ratio
-    tnr = tnr_ecma_st(audio, fs, prominence=True)
+    t_tnr, tnr, prom, tones_freqs = tnr_ecma_st(audio, fs, prominence=True)
         
 if __name__ == "__main__":
     test_tnr_ecma_st()

--- a/tests/sq_metrics/tonality/test_tnr_ecma_st.py
+++ b/tests/sq_metrics/tonality/test_tnr_ecma_st.py
@@ -9,7 +9,7 @@ except ImportError:
         "In order to perform the tests you need the 'pytest' package."
     )
 
-
+import numpy as np
 # Local application imports
 from mosqito.utils import load
 from mosqito.sq_metrics import tnr_ecma_st
@@ -30,18 +30,21 @@ def test_tnr_ecma_st():
     -------
     None
     """
-    # Test signal as input for prominence ratio calculation
-    # signals generated using audacity : white noise + tones at 200 and 2000 Hz
+    # Test signal as input for tone to noise ratio calculation
+    # signals generated using audacity : white noise + tones at 442 and 1768 Hz
 
     signal =  {
-            "tones freq": [200, 2000],
+            "tones freq": [442, 1768],
             "data_file": "tests/input/white_noise_442_1768_Hz_stationary.wav"
         }
 
     # Load signal
-    audio, fs = load(signal["data_file"])
+    audio, fs = load(signal["data_file"], wav_calib=0.01)
     # Compute tone-to-noise ratio
-    t_tnr, tnr, prom, tones_freqs = tnr_ecma_st(audio, fs, prominence=True)
+    t_tnr, tnr, prom, freq = tnr_ecma_st(audio, fs, prominence=True)
+    np.testing.assert_almost_equal(t_tnr, 32.7142766)
+    np.testing.assert_almost_equal(freq.astype(np.int32), [442, 1768])
+    assert np.count_nonzero(prom == True) == 2
         
 if __name__ == "__main__":
     test_tnr_ecma_st()

--- a/tests/sq_metrics/tonality/test_tnr_ecma_tv.py
+++ b/tests/sq_metrics/tonality/test_tnr_ecma_tv.py
@@ -28,17 +28,20 @@ def test_tnr_ecma_tv():
     None
     """
     # Test signal as input for prominence ratio calculation
-    # signals generated using audacity : white noise + tones at 200 and 2000 Hz
+    # signals generated using audacity : white noise + tones at 442 and 1768 Hz
 
-    signal = {"data_file": "tests/input/white_noise_442_1768_Hz_varying.wav"}
+    signal = {"freq": [442, 1768],
+        "data_file": "tests/input/white_noise_442_1768_Hz_varying.wav"}
 
     # Load signal
-    audio, fs = load(signal["data_file"])
+    audio, fs = load(signal["data_file"], wav_calib=0.01)
 
     # Compute tone-to-noise ratio
     t_tnr, tnr, prom, freq, time = tnr_ecma_tv(audio, fs, prominence=True)
-    np.testing.assert_almost_equal(max(t_tnr), 34.995108238375025)
-    assert np.count_nonzero(prom == True) == 6
+    np.testing.assert_almost_equal(max(t_tnr), 34.710964273840155)
+    assert tnr[np.argmin(np.abs(freq-442)),:].all() != np.nan
+    assert tnr[np.argmin(np.abs(freq-1768)),2:3].all() != np.nan
+    assert np.count_nonzero(prom == True) == 8
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
+ The function noct_synthesis and noct_freq_filter have been enhanced for better accuracy compared to the filtering in time domain. The function butter and sosfreqz from scipy.signal are used. 
+ In time domain, the use of a,b filter representation have been replaced by sos to improve the performance of noct_spectrum.
+ The function screening_for_tones has been corrected to correctly detect a potential peak on the first index
+ The function spectrum_smoothing now takes as input a spectrum of  dimension (nperseg, nseg) as the rest of the functions

All the tests are running without any warning.

Tks :)