### PR TITLE
Fix DeprecationWarning regarding conversion of array to scalar

### DIFF
--- a/mosqito/sq_metrics/sharpness/sharpness_din/sharpness_din_from_loudness.py
+++ b/mosqito/sq_metrics/sharpness/sharpness_din/sharpness_din_from_loudness.py
@@ -63,7 +63,7 @@ def sharpness_din_from_loudness(N, N_specific, weighting="din", skip=0):
                       z * 0.1, axis=0) / N
 
     if S.size == 1:
-        S = float(S)
+        S = S.flat[0]
     else:
         S = np.squeeze(S)
         S[ind] = 0


### PR DESCRIPTION
Using a recent version of numpy the following deprecation warning is given:

`mosqito/sq_metrics/sharpness/sharpness_din/sharpness_din_from_loudness.py:69: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)`

This commit fix this warning by using `flatiter` (https://numpy.org/doc/stable/reference/generated/numpy.flatiter.html) to extract the first (and only) element from the array in the case it is scalar.